### PR TITLE
Set up Docker build and push to Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Build & test - Java + Angular
 
 on:
-  push:
-    branches: [ main, feature/docker-deploy ]
   pull_request:
     branches: [ main ]
 
@@ -137,7 +135,7 @@ jobs:
 
 
   docker-publish:
-    name: Docker build & push
+    name: Docker build & push to Docker hub
     runs-on: ubuntu-latest
     needs: [ test-back, test-front, sonarcloud-front ]
     if: ${{ success() }}
@@ -147,14 +145,12 @@ jobs:
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
-      # Build & push back-end image
       - name: Build and push back-end Docker image
         working-directory: back
         run: |
           docker build -t celineintha/p10-back:latest .
           docker push celineintha/p10-back:latest
 
-      # Build & push front-end image
       - name: Build and push front-end Docker image
         working-directory: front
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build & test - Java + Angular
 
 on:
   push:
-    branches: [ main, feature/ci-cd ]
+    branches: [ main, feature/docker-deploy ]
   pull_request:
     branches: [ main ]
 
@@ -134,3 +134,28 @@ jobs:
             -Dsonar.test.inclusions=**/*.spec.ts \
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info \
             -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+
+
+  docker-publish:
+    name: Docker build & push
+    runs-on: ubuntu-latest
+    needs: [ test-back, test-front, sonarcloud-front ]
+    if: ${{ success() }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      # Build & push back-end image
+      - name: Build and push back-end Docker image
+        working-directory: back
+        run: |
+          docker build -t celineintha/p10-back:latest .
+          docker push celineintha/p10-back:latest
+
+      # Build & push front-end image
+      - name: Build and push front-end Docker image
+        working-directory: front
+        run: |
+          docker build -t celineintha/p10-front:latest .


### PR DESCRIPTION
This pull request introduces Docker support and automated image deployment :
- Build docker images : front and back
- Push to Docker Hub (`celineintha/p10-front` and `celineintha/p10-back`)
- Workflow only triggers on pull requests to `main`
- Docker deployment only runs if tests and code quality checks succeed
